### PR TITLE
new functions: init, add remote

### DIFF
--- a/src/git.erl
+++ b/src/git.erl
@@ -7,6 +7,7 @@
          fetch/1,
          checkout/2, checkout/3,
          remote/1,
+         remote/2, remote/3,
 
          status_is_detached/1,
          status_is_dirty/1,
@@ -137,6 +138,20 @@ remote(Repo) ->
 string_to_remote(X) ->
      [Name, Url, _] = string:tokens(X, "\t "),
      {Name, Url}.
+
+%%
+%% add git remote to existed repository
+-spec(remote/2 :: (dir(), url()) -> ok | {error, any()}).
+-spec(remote/3 :: (dir(), list(), url()) -> ok | {error, any()}).
+
+remote(RepoDir, RepoURL) ->
+    remote(RepoDir, "origin", RepoURL).
+
+remote(RepoDir, RemoteName, RepoURL) ->
+   sh(remote_add_cmd(RemoteName, RepoURL), [{cd, RepoDir}]).
+
+remote_add_cmd(RemoteName, RepoURL) ->
+    fformat("git remote add -t \\* -f ~s ~s", [RemoteName, RepoURL]).
 
 
 -spec branch(dir()) -> {'ok', branch()} | 'detached'.


### PR DESCRIPTION
Hello,

I got a problem with git:clone, it failes
   fatal: destination path '...' already exists and is not an empty directory.

the issue comes by the fact that I need to "clone" repository to existed empty folder. Due to nature of my app, I cannon remove that folder.

The typical git workflow to overcome depicted problem is following:

git init .
git remote add -t * -f origin <repository-url>
git co master 

I've added equivalent function to the library

git:init("/tmp/erlgit").
git:remote("/tmp/erlgit", "https://github.com/fogfish/erlgit").
git:checkout("/tmp/erlgit", "master").
