### PR TITLE
Add missing dep

### DIFF
--- a/src/erlgit.app.src
+++ b/src/erlgit.app.src
@@ -6,7 +6,8 @@
   {applications, [
                   kernel,
                   stdlib,
-                  erlsemver
+                  erlsemver,
+                  sh
                  ]},
   {env, []}
  ]}.


### PR DESCRIPTION
erlgit uses the sh library but does not register it. This breaks some internal tools for us that traverses dependencies.

This commit fixes that issue.
