### PR TITLE
Fix git:branch bug when there is more than one branch with equal SHA-ID

### DIFF
--- a/src/git.erl
+++ b/src/git.erl
@@ -56,7 +56,7 @@
 
 -import(git_utils, [fformat/2, strip/1, join/2]).
 
--include_lib("../deps/erlsemver/include/semver.hrl").
+-include_lib("erlsemver/include/semver.hrl").
 
 %% =============================================================================
 %%


### PR DESCRIPTION
This fixes badmatch error when we have more than one branch with equal sha-id. In such case, you tried to match one-element list ([B]) with list of branches (["branchA", "branchB"]). Now we just return list of branches, separated with "; ", ex. "branchA; branchB"
